### PR TITLE
fix(github): rename org

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     url: https://gov.yearn.finance/
     about: Please ask and answer questions here.
   - name: Yearn Finance Security & Bug Bounty
-    url: https://github.com/iearn-finance/yearn-security
+    url: https://github.com/yearn/yearn-security
     about: Please report security vulnerabilities here.

--- a/.github/workflows/board.yml
+++ b/.github/workflows/board.yml
@@ -13,6 +13,6 @@ jobs:
         uses: peter-evans/create-or-update-project-card@v1
         with:
           token: ${{ secrets.PAT }}
-          project-location: iearn-finance
+          project-location: yearn
           project-name: Web
           column-name: Back log

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
  <p align="center">
 <align="center">
  
-![Validate](https://github.com/iearn-finance/YIPS/workflows/Validate/badge.svg?branch=master) [![Discord](https://img.shields.io/discord/734804446353031319.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discordapp.com/channels/734804446353031319/) [![Telegram](https://img.shields.io/badge/chat-on%20Telegram-blue.svg)](https://t.me/yearnfinance) [![Twitter Follow](https://img.shields.io/twitter/follow/iearnfinance.svg?label=iearnfinance&style=social)](https://twitter.com/iearnfinance)
+![Validate](https://github.com/yearn/YIPS/workflows/Validate/badge.svg?branch=master) [![Discord](https://img.shields.io/discord/734804446353031319.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discordapp.com/channels/734804446353031319/) [![Telegram](https://img.shields.io/badge/chat-on%20Telegram-blue.svg)](https://t.me/yearnfinance) [![Twitter Follow](https://img.shields.io/twitter/follow/iearnfinance.svg?label=iearnfinance&style=social)](https://twitter.com/iearnfinance)
 
 - [YIPs](#yips)
   * [Contributing](#contributing)
@@ -27,7 +27,7 @@
 1.  Review [YIP-0](YIPS/yip-0.md).
 2.  Fork the repository by clicking "Fork" in the top right.
 3.  Add your YIP to your fork of the repository. There is a [template YIP here](yip-X.md).
-4.  Submit a Pull Request to Yearn's [YIPs repository](https://github.com/iearn-finance/YIPS/).
+4.  Submit a Pull Request to Yearn's [YIPs repository](https://github.com/yearn/YIPS/).
 
 Your first PR should be a first draft of the final YIP. It must meet the formatting criteria enforced by the build (largely, correct metadata in the header). An editor will manually review the first PR for a new YIP and assign it a number before merging it. Make sure you include a `discussions-to` header with the URL to a new thread on [gov.yearn.finance](https://gov.yearn.finance/) where people can discuss the YIP as a whole.
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
  <p align="center">
 <align="center">
  
-![Validate](https://github.com/yearn/YIPS/workflows/Validate/badge.svg?branch=master) [![Discord](https://img.shields.io/discord/734804446353031319.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discordapp.com/channels/734804446353031319/) [![Telegram](https://img.shields.io/badge/chat-on%20Telegram-blue.svg)](https://t.me/yearnfinance) [![Twitter Follow](https://img.shields.io/twitter/follow/iearnfinance.svg?label=iearnfinance&style=social)](https://twitter.com/iearnfinance)
+![Validate](https://github.com/iearn-finance/YIPS/workflows/Validate/badge.svg?branch=master) [![Discord](https://img.shields.io/discord/734804446353031319.svg?color=768AD4&label=discord&logo=https%3A%2F%2Fdiscordapp.com%2Fassets%2F8c9701b98ad4372b58f13fd9f65f966e.svg)](https://discordapp.com/channels/734804446353031319/) [![Telegram](https://img.shields.io/badge/chat-on%20Telegram-blue.svg)](https://t.me/yearnfinance) [![Twitter Follow](https://img.shields.io/twitter/follow/iearnfinance.svg?label=iearnfinance&style=social)](https://twitter.com/iearnfinance)
 
 - [YIPs](#yips)
   * [Contributing](#contributing)
@@ -27,7 +27,7 @@
 1.  Review [YIP-0](YIPS/yip-0.md).
 2.  Fork the repository by clicking "Fork" in the top right.
 3.  Add your YIP to your fork of the repository. There is a [template YIP here](yip-X.md).
-4.  Submit a Pull Request to Yearn's [YIPs repository](https://github.com/yearn/YIPS/).
+4.  Submit a Pull Request to Yearn's [YIPs repository](https://github.com/iearn-finance/YIPS/).
 
 Your first PR should be a first draft of the final YIP. It must meet the formatting criteria enforced by the build (largely, correct metadata in the header). An editor will manually review the first PR for a new YIP and assign it a number before merging it. Make sure you include a `discussions-to` header with the URL to a new thread on [gov.yearn.finance](https://gov.yearn.finance/) where people can discuss the YIP as a whole.
 
@@ -57,7 +57,7 @@ gem install yip_validator
 yip_validator <INPUT_FILES>
 ```
 
-## YIP Geneartor
+## YIP Generator
 
 A YIP Generator is available [as a nodejs package here](https://github.com/sambacha/generator-yyip).
 

--- a/YIPS/yip-0.md
+++ b/YIPS/yip-0.md
@@ -173,7 +173,7 @@ The YIP document was derived heavily from the SIP Synthetix Improvement Proposal
 
 [the unofficial yearn discord]: https://discord.com/invite/3AGgWxy
 [the unofficial yearn telegram]: https://t.me/yearnfinance
-[pull request]: https://github.com/iearn-finance/YIPS/pulls
+[pull request]: https://github.com/yearn/YIPS/pulls
 [markdown]: https://github.com/adam-p/markdown-here/wiki/Markdown-Cheatsheet
 
 ## Copyright

--- a/YIPS/yip-31.md
+++ b/YIPS/yip-31.md
@@ -38,7 +38,7 @@ Some YFI should be reserved to secure and improve the yearn ecosystem while prop
 
 Reference
 
-- Inflation schedule proposal [YIP-30](https://github.com/iearn-finance/YIPS/blob/master/YIPS/yip-30.md)
+- Inflation schedule proposal [YIP-30](https://github.com/yearn/YIPS/blob/master/YIPS/yip-30.md)
 
 ## Metadata
 

--- a/YIPS/yip-43.md
+++ b/YIPS/yip-43.md
@@ -127,7 +127,7 @@ Discussions-to: <Create a new thread on https://gov.yearn.finance/ and drop the 
 #### YIP Validator (Ruby Gem)
 
 > current version: `1.0.2`, should be bumped to `1.1.0`
-> Changes located [github.com/iearn-finance/yip_validator/blob/master/lib/yip_validator/validator.rb#L25](https://github.com/iearn-finance/yip_validator/blob/master/lib/yip_validator/validator.rb#L25)
+> Changes located [github.com/yearn/yip_validator/blob/master/lib/yip_validator/validator.rb#L25](https://github.com/yearn/yip_validator/blob/master/lib/yip_validator/validator.rb#L25)
 
 ```ruby
     validates_inclusion_of :status, in: ['WIP', 'Proposed', 'Approved', 'Implemented', 'Rejected']

--- a/YIPS/yip-44.md
+++ b/YIPS/yip-44.md
@@ -127,7 +127,7 @@ Discussions-to: <Create a new thread on https://gov.yearn.finance/ and drop the 
 #### YIP Validator (Ruby Gem)
 
 > current version: `1.0.2`, should be bumped to `1.1.0`
-> Changes located [github.com/iearn-finance/yip_validator/blob/master/lib/yip_validator/validator.rb#L25](https://github.com/iearn-finance/yip_validator/blob/master/lib/yip_validator/validator.rb#L25)
+> Changes located [github.com/yearn/yip_validator/blob/master/lib/yip_validator/validator.rb#L25](https://github.com/yearn/yip_validator/blob/master/lib/yip_validator/validator.rb#L25)
 
 ```ruby
     validates_inclusion_of :status, in: ['WIP', 'Proposed', 'Approved', 'Implemented', 'Rejected']

--- a/YIPS/yip-54.md
+++ b/YIPS/yip-54.md
@@ -156,7 +156,7 @@ _Source: [Snapshot](https://snapshot.page/#/yearn/proposal/QmW2ZPfGrcNxVLvT2jm9f
 <a id="5">5. Dataset available on request</a>
 <a id="6">6. https://snapshot.page/#/yearn/proposal/QmSaYHR97LDMDvg9xeTfdNZw6aqL9njxBKM6JVFtCYxKvB</a>
 <a id="7">7. https://snapshot.page/#/yearn/proposal/QmbAq6jPB6ocrihjkDo5TLNF4D4w9dw1HsEsJ7vwdwd9g3</a>
-<a id="8">8. https://github.com/iearn-finance/ychad-audit/tree/master/reports/financial</a>
+<a id="8">8. https://github.com/yearn/ychad-audit/tree/master/reports/financial</a>
 
 ## Copyright
 

--- a/_config.yml
+++ b/_config.yml
@@ -18,9 +18,9 @@ description: >-
   platform, including core protocol specifications, client APIs, and contract
   standards.
 url: "https://yips.yearn.finance"
-repository: iearn-finance/YIPS
+repository: yearn/YIPS
 twitter_username: iearnfinance
-github_username: iearn-finance
+github_username: yearn
 header_pages:
   - all-yip.html
 twitter:

--- a/_includes/social.html
+++ b/_includes/social.html
@@ -37,13 +37,13 @@
   </li>
   {%- endif -%}
   <li>
-    <a href="https://github.com/iearn-finance/YIPS"
+    <a href="https://github.com/yearn/YIPS"
       ><svg class="svg-icon">
         <use
           xlink:href="{{ '/assets/minima-social-icons.svg#github' | relative_url }}"
         ></use>
       </svg>
-      <span class="username">iearn-finance/YIPS</span></a
+      <span class="username">yearn/YIPS</span></a
     >
   </li>
   {%- if site.instagram_username -%}

--- a/index.html
+++ b/index.html
@@ -24,13 +24,13 @@ title: Yearn Improvement Proposals
   <li>Fork the repository by clicking "Fork" in the top right.</li>
   <li>
     Add your YIP to your fork of the repository. There is a
-    <a href="https://github.com/iearn-finance/YIPS/blob/master/yip-X.md"
+    <a href="https://github.com/yearn/YIPS/blob/master/yip-X.md"
       >template YIP here</a
     >.
   </li>
   <li>
     Submit a Pull Request to Yearn's
-    <a href="https://github.com/iearn-finance/YIPS">YIPs repository</a>.
+    <a href="https://github.com/yearn/YIPS">YIPs repository</a>.
   </li>
 </ol>
 

--- a/last-call.xml
+++ b/last-call.xml
@@ -17,7 +17,7 @@ layout: null
         {% if YIP.discussions-to %}
           <p>The author has requested that discussions happen at the following URL: {{ YIP.discussions-to }}</p>
         {% else %}
-          <p>Please visit the [iearn-finance/YIPs issues to comment](https://github.com/iearn-finance/YIPs/issues/{{YIP.YIP}}).</p>
+          <p>Please visit the [yearn/YIPs issues to comment](https://github.com/yearn/YIPs/issues/{{YIP.YIP}}).</p>
         {% endif %}
         <hr />
         {{ YIP.content }}        


### PR DESCRIPTION
This PR fixes the namespace to the new `github.com/yearn` org

also fixes some minor markup and spelling mistakes on the README